### PR TITLE
Another workaround

### DIFF
--- a/lib/HTTP/Easy.pm6
+++ b/lib/HTTP/Easy.pm6
@@ -53,9 +53,14 @@ method run
   {
     if $.debug { message("Client connection received."); }
     self.on-connection;
+
     my $preamble = $!connection.get;
-    say "It is cut here\n ------->", $preamble, "\n<---------";
+    ## This is temporary workaound
+    # Second get is needed looks like bug in rakudo.
+    # We just go along with that
+    say "It is cut here\n------->\n", $preamble, "\n<---------";
     $preamble ~= $!connection.get;
+    ## End of work around.
     my @headers = $preamble.split("\r\n");
     my $request = @headers.shift;
     unless defined $request


### PR DESCRIPTION
I prepared much more compact version of this bug workaround. Would you like take a look? It will break when rakudo (or parrot) get fixed. It depends on your coding policy it is better or worse...

One thing I noticed it is not only newline related (its like to break after other chars).

For example:

```
Entering the development dance floor: http://0.0.0.0:3000
[2013-03-22T21:39:28Z] Started HTTP server.
 It is cut here
 ------->
GET / HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:10.0.7) Gecko/20100101 Firefox/10.0.7 I
<---------
```

This is my rakudo versions

```
$ perl6 --version
This is perl6 version 2013.02.1-153-g8fea533 built on parrot 4.10.0 revision RELEASE_4_10_0
This is perl6 version 2013.03-2-gb972ca3 built on parrot 4.10.0 revision RELEASE_4_10_0
```
