### PR TITLE
Dataless connection fix

### DIFF
--- a/lib/HTTP/Easy.pm6
+++ b/lib/HTTP/Easy.pm6
@@ -58,6 +58,7 @@ method run
     my $msg-body-pos;
 
     while my $t = $!connection.recv( :bin ) {
+        if $!debug { message("Received a chunk of { $t.elems } bytes length") }
         if $first-chunk.defined {
             $first-chunk = $first-chunk ~ $t;
         } else {


### PR DESCRIPTION
firefox will open up connections and not send anything, then a timeout happens and our recv ends up returning Any.

we used to crash, now we'll just close the socket and move on.
