### PR TITLE
Add unit declarator to role declarations

### DIFF
--- a/lib/HTTP/Easy.pm6
+++ b/lib/HTTP/Easy.pm6
@@ -1,7 +1,7 @@
 ## A simple HTTP Daemon role. Inspired by HTTP::Server::Simple
 ## See HTTP::Easy::PSGI as the default daemon class implementation.
 
-role HTTP::Easy:ver<2.1.3>:auth<http://supernovus.github.com/>;
+unit role HTTP::Easy:ver<2.1.3>:auth<http://supernovus.github.com/>;
 
 use HTTP::Status;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.