### PR TITLE
Remove obsolete input-line-separator from IO::Socket::INET.new() call

### DIFF
--- a/lib/HTTP/Easy.pm6
+++ b/lib/HTTP/Easy.pm6
@@ -35,8 +35,7 @@ method connect (:$port=$.port, :$host=$.host)
   $!listener = IO::Socket::INET.new(
     :localhost($host),
     :localport($port),
-    :listen(1),
-    :input-line-separator(CRLF ~ CRLF)
+    :listen
   );
 }
 


### PR DESCRIPTION
input-line-separator was removed from IO::Socket::INET.new()
